### PR TITLE
feat: homepage public note feed and note create/edit form

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,9 @@ import { AuthProvider, useAuth } from './context/AuthContext'
 import Navbar from './components/Navbar'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
+import HomePage from './pages/HomePage'
+import NoteFormPage from './pages/NoteFormPage'
+import NoteDetailPage from './pages/NoteDetailPage'
 
 function ProtectedRoute({ children }) {
   const { user, loading } = useAuth()
@@ -18,14 +21,6 @@ function ProtectedRoute({ children }) {
   return user ? children : <Navigate to="/login" replace />
 }
 
-function NotesPage() {
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <h1 className="text-2xl font-bold text-gray-900">Notes (coming soon)</h1>
-    </div>
-  )
-}
-
 function App() {
   return (
     <AuthProvider>
@@ -35,7 +30,14 @@ function App() {
           <Route path="/" element={<Navigate to="/notes" replace />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
-          <Route path="/notes" element={<NotesPage />} />
+          <Route path="/notes" element={<HomePage />} />
+          <Route path="/notes/new" element={
+            <ProtectedRoute><NoteFormPage /></ProtectedRoute>
+          } />
+          <Route path="/notes/:id/edit" element={
+            <ProtectedRoute><NoteFormPage /></ProtectedRoute>
+          } />
+          <Route path="/notes/:id" element={<NoteDetailPage />} />
         </Routes>
       </div>
     </AuthProvider>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { getNotes } from '../services/api'
+import { useAuth } from '../context/AuthContext'
+
+function NoteCard({ note }) {
+  return (
+    <Link
+      to={`/notes/${note.id}`}
+      className="block bg-white rounded-lg border border-gray-200 p-4 hover:shadow-md transition"
+    >
+      <h3 className="font-semibold text-gray-900 truncate">{note.title}</h3>
+      {note.course && (
+        <p className="text-xs text-blue-600 mt-1 font-medium">{note.course}</p>
+      )}
+      <p className="text-sm text-gray-500 mt-1">by {note.author}</p>
+      {note.tags?.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-2">
+          {note.tags.map(tag => (
+            <span
+              key={tag}
+              className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center justify-between mt-3 text-xs text-gray-400">
+        <span>{new Date(note.created_at).toLocaleDateString()}</span>
+        <span>♥ {note.like_count ?? 0}</span>
+      </div>
+    </Link>
+  )
+}
+
+function HomePage() {
+  const { user } = useAuth()
+  const [notes, setNotes] = useState([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [hasNextPage, setHasNextPage] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    setLoading(true)
+    getNotes({ page, limit: 12 })
+      .then(data => {
+        setNotes(data.notes)
+        setTotal(data.total)
+        setHasNextPage(data.hasNextPage)
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [page])
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">
+          Public Notes {total > 0 && <span className="text-gray-400 font-normal text-lg">({total})</span>}
+        </h1>
+        {user && (
+          <Link
+            to="/notes/new"
+            className="bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-blue-700 transition"
+          >
+            + New Note
+          </Link>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-20">
+          <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : notes.length === 0 ? (
+        <div className="text-center py-20 text-gray-500">
+          No notes found. Be the first to share one!
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {notes.map(note => (
+            <NoteCard key={note.id} note={note} />
+          ))}
+        </div>
+      )}
+
+      {(page > 1 || hasNextPage) && (
+        <div className="flex justify-center items-center gap-4 mt-8">
+          <button
+            onClick={() => setPage(p => p - 1)}
+            disabled={page === 1}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-md disabled:opacity-40 hover:bg-gray-50 transition"
+          >
+            Previous
+          </button>
+          <span className="text-sm text-gray-600">Page {page}</span>
+          <button
+            onClick={() => setPage(p => p + 1)}
+            disabled={!hasNextPage}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-md disabled:opacity-40 hover:bg-gray-50 transition"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default HomePage

--- a/frontend/src/pages/NoteDetailPage.jsx
+++ b/frontend/src/pages/NoteDetailPage.jsx
@@ -1,0 +1,12 @@
+import { useParams } from 'react-router-dom'
+
+function NoteDetailPage() {
+  const { id } = useParams()
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h1 className="text-2xl font-bold text-gray-900">Note #{id} (coming soon)</h1>
+    </div>
+  )
+}
+
+export default NoteDetailPage

--- a/frontend/src/pages/NoteFormPage.jsx
+++ b/frontend/src/pages/NoteFormPage.jsx
@@ -1,0 +1,174 @@
+import { useState, useEffect } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { createNote, updateNote, getNote } from '../services/api'
+
+function NoteFormPage() {
+  const navigate = useNavigate()
+  const { id } = useParams()
+  const isEdit = Boolean(id)
+
+  const [formData, setFormData] = useState({
+    title: '',
+    content: '',
+    course: '',
+    is_public: false,
+    tags: '',
+  })
+  const [errors, setErrors] = useState({})
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!isEdit) return
+    getNote(id)
+      .then(note => {
+        setFormData({
+          title: note.title,
+          content: note.content || '',
+          course: note.course || '',
+          is_public: note.is_public,
+          tags: (note.tags || []).join(', '),
+        })
+      })
+      .catch(() => navigate('/notes'))
+  }, [id, isEdit, navigate])
+
+  const validate = () => {
+    const errs = {}
+    if (!formData.title.trim()) errs.title = 'Title is required'
+    const tagList = formData.tags.split(',').map(t => t.trim()).filter(Boolean)
+    if (tagList.length > 10) errs.tags = 'Maximum 10 tags allowed'
+    return errs
+  }
+
+  const handleChange = (field) => (e) =>
+    setFormData(p => ({ ...p, [field]: e.target.value }))
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const errs = validate()
+    if (Object.keys(errs).length > 0) { setErrors(errs); return }
+
+    const payload = {
+      ...formData,
+      tags: formData.tags.split(',').map(t => t.trim()).filter(Boolean),
+    }
+
+    setLoading(true)
+    try {
+      if (isEdit) {
+        await updateNote(id, payload)
+        navigate(`/notes/${id}`)
+      } else {
+        const note = await createNote(payload)
+        navigate(`/notes/${note.id}`)
+      }
+    } catch (err) {
+      setErrors({ api: err.message })
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">
+        {isEdit ? 'Edit Note' : 'New Note'}
+      </h1>
+
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg border border-gray-200 space-y-5">
+        {errors.api && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 border border-red-200">
+            {errors.api}
+          </div>
+        )}
+
+        <div>
+          {errors.title && <p className="text-sm text-red-600 mb-1">{errors.title}</p>}
+          <label className="block text-sm font-medium text-gray-700 mb-1">Title *</label>
+          <input
+            type="text"
+            value={formData.title}
+            onChange={handleChange('title')}
+            className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.title ? 'border-red-500' : 'border-gray-300'
+            }`}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Content</label>
+          <textarea
+            rows={8}
+            value={formData.content}
+            onChange={handleChange('content')}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Course</label>
+          <input
+            type="text"
+            value={formData.course}
+            onChange={handleChange('course')}
+            placeholder="e.g. CS101"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        <div>
+          {errors.tags && <p className="text-sm text-red-600 mb-1">{errors.tags}</p>}
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Tags <span className="text-gray-400 font-normal">(comma separated, max 10)</span>
+          </label>
+          <input
+            type="text"
+            value={formData.tags}
+            onChange={handleChange('tags')}
+            placeholder="e.g. exam, midterm, calculus"
+            className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.tags ? 'border-red-500' : 'border-gray-300'
+            }`}
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setFormData(p => ({ ...p, is_public: !p.is_public }))}
+            className={`relative w-11 h-6 rounded-full transition-colors ${
+              formData.is_public ? 'bg-blue-600' : 'bg-gray-300'
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+                formData.is_public ? 'translate-x-5' : ''
+              }`}
+            />
+          </button>
+          <span className="text-sm text-gray-700">
+            {formData.is_public ? 'Public' : 'Private'}
+          </span>
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex-1 bg-blue-600 text-white py-2 rounded-md font-medium hover:bg-blue-700 transition disabled:opacity-60"
+          >
+            {loading ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Note'}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="px-6 py-2 border border-gray-300 rounded-md text-sm text-gray-600 hover:bg-gray-50 transition"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default NoteFormPage

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,10 +1,18 @@
 const BASE_URL = import.meta.env.VITE_API_URL ?? '/api'
 
+function getToken() {
+  return localStorage.getItem('token')
+}
+
 async function request(path, options = {}) {
-  const res = await fetch(`${BASE_URL}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...options.headers },
-    ...options,
-  })
+  const token = getToken()
+  const headers = { 'Content-Type': 'application/json', ...options.headers }
+  if (token) headers.Authorization = `Bearer ${token}`
+
+  const res = await fetch(`${BASE_URL}${path}`, { headers, ...options })
+
+  if (res.status === 204) return null
+
   const data = await res.json()
   if (!res.ok) {
     const err = new Error(data.error ?? 'Something went wrong')
@@ -26,4 +34,25 @@ export async function loginUser(email, password) {
     method: 'POST',
     body: JSON.stringify({ email, password }),
   })
+}
+
+export async function getNotes(params = {}) {
+  const query = new URLSearchParams(params).toString()
+  return request(`/notes${query ? `?${query}` : ''}`)
+}
+
+export async function getNote(id) {
+  return request(`/notes/${id}`)
+}
+
+export async function createNote(data) {
+  return request('/notes', { method: 'POST', body: JSON.stringify(data) })
+}
+
+export async function updateNote(id, data) {
+  return request(`/notes/${id}`, { method: 'PUT', body: JSON.stringify(data) })
+}
+
+export async function deleteNote(id) {
+  return request(`/notes/${id}`, { method: 'DELETE' })
 }


### PR DESCRIPTION
## Summary
- **api.js** updated: auto-attaches Bearer token to all requests; adds `getNotes`, `getNote`, `createNote`, `updateNote`, `deleteNote`
- **HomePage** (`/notes`): fetches public notes, note cards with title/author/course/tags/date/likes, Previous/Next pagination, empty state message, "+ New Note" button for logged-in users
- **NoteFormPage** (`/notes/new` and `/notes/:id/edit`):
  - Fields: title (required), content, course, tags (comma separated, max 10), public/private toggle
  - Create → `POST /api/notes` → redirect to `/notes/:id`
  - Edit → pre-filled with existing data → `PUT /api/notes/:id` → redirect back
  - Cancel returns to previous page without saving
- **NoteDetailPage** (`/notes/:id`): placeholder (issue #18)
- `/notes/new` and `/notes/:id/edit` are protected routes

> Depends on PR #39 (Navbar) and PR #40 (notes endpoints)

Closes #15
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)