### PR TITLE
feat: CORS configuration and rate limiting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,6 @@
 PORT=5010
+NODE_ENV=development
+FRONTEND_URL=https://your-vercel-app.vercel.app
 
 # Supabase — get these from Project Settings → API on supabase.com
 SUPABASE_URL=https://your-project-id.supabase.co

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,15 +1,40 @@
 import express from 'express'
 import cors from 'cors'
+import rateLimit from 'express-rate-limit'
 import 'dotenv/config'
 import authRoutes from './routes/auth.js'
 
 const app = express()
 const PORT = process.env.PORT || 5010
 
-app.use(cors())
+const corsOptions = {
+  origin: process.env.NODE_ENV === 'production'
+    ? process.env.FRONTEND_URL
+    : 'http://localhost:5173',
+  credentials: true,
+}
+
+const globalLimit = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests' },
+})
+
+const authLimit = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests' },
+})
+
+app.use(cors(corsOptions))
+app.use(globalLimit)
 app.use(express.json())
 
-app.use('/api/auth', authRoutes)
+app.use('/api/auth', authLimit, authRoutes)
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`)


### PR DESCRIPTION
## Summary
- CORS allows `http://localhost:5173` in development, `FRONTEND_URL` env var in production
- Global rate limit: **100 req / 15 min** per IP; returns `429 { error: "Too many requests" }`
- Auth routes stricter: **10 req / 15 min** per IP
- Added `FRONTEND_URL` and `NODE_ENV` to `.env.example`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)