### PR TITLE
feat: user profile page and endpoints

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,7 @@ import express from 'express'
 import cors from 'cors'
 import 'dotenv/config'
 import authRoutes from './routes/auth.js'
+import usersRoutes from './routes/users.js'
 
 const app = express()
 const PORT = process.env.PORT || 5010
@@ -10,6 +11,7 @@ app.use(cors())
 app.use(express.json())
 
 app.use('/api/auth', authRoutes)
+app.use('/api/users', usersRoutes)
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`)

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,16 @@
+import supabase from '../services/supabase.js'
+
+export async function requireAuth(req, res, next) {
+  const token = req.headers.authorization?.startsWith('Bearer ')
+    ? req.headers.authorization.slice(7)
+    : null
+
+  if (!token) return res.status(401).json({ error: 'Authentication required' })
+
+  const { data, error } = await supabase.auth.getUser(token)
+
+  if (error || !data.user) return res.status(401).json({ error: 'Invalid or expired token' })
+
+  req.user = data.user
+  next()
+}

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,70 @@
+import { Router } from 'express'
+import { body } from 'express-validator'
+import supabase from '../services/supabase.js'
+import { requireAuth } from '../middleware/auth.js'
+
+const router = Router()
+
+// GET /api/users/:id
+router.get('/:id', async (req, res) => {
+  const { id } = req.params
+
+  const { data: user, error } = await supabase
+    .from('users')
+    .select('id, username, created_at')
+    .eq('id', id)
+    .single()
+
+  if (error || !user) return res.status(404).json({ error: 'User not found' })
+
+  const { count } = await supabase
+    .from('notes')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', id)
+    .eq('is_public', true)
+
+  return res.status(200).json({ ...user, note_count: count ?? 0 })
+})
+
+// GET /api/users/:id/notes
+router.get('/:id/notes', async (req, res) => {
+  const { data: notes, error } = await supabase
+    .from('notes')
+    .select('*, users!fk_notes_user(username), note_tags(tags(name))')
+    .eq('user_id', req.params.id)
+    .eq('is_public', true)
+    .order('created_at', { ascending: false })
+
+  if (error) return res.status(500).json({ error: error.message })
+
+  return res.status(200).json(
+    (notes || []).map(note => ({
+      ...note,
+      author: note.users?.username ?? null,
+      tags: (note.note_tags || []).map(nt => nt.tags?.name).filter(Boolean),
+      users: undefined,
+      note_tags: undefined,
+    }))
+  )
+})
+
+// PUT /api/users/me  — update own username
+router.put('/me', requireAuth, async (req, res) => {
+  const { username } = req.body
+  if (!username?.trim() || username.trim().length < 3) {
+    return res.status(400).json({ error: 'Username must be at least 3 characters' })
+  }
+
+  const { data, error } = await supabase
+    .from('users')
+    .update({ username: username.trim() })
+    .eq('id', req.user.id)
+    .select('id, username, created_at')
+    .single()
+
+  if (error) return res.status(500).json({ error: error.message })
+
+  return res.status(200).json(data)
+})
+
+export default router

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import RegisterPage from './pages/RegisterPage'
 import HomePage from './pages/HomePage'
 import NoteFormPage from './pages/NoteFormPage'
 import NoteDetailPage from './pages/NoteDetailPage'
+import ProfilePage from './pages/ProfilePage'
 
 function ProtectedRoute({ children }) {
   const { user, loading } = useAuth()
@@ -38,6 +39,7 @@ function App() {
             <ProtectedRoute><NoteFormPage /></ProtectedRoute>
           } />
           <Route path="/notes/:id" element={<NoteDetailPage />} />
+          <Route path="/profile/:id" element={<ProfilePage />} />
         </Routes>
       </div>
     </AuthProvider>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,0 +1,122 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { getUser, getUserNotes, updateUsername } from '../services/api'
+import { useAuth } from '../context/AuthContext'
+
+function NoteCard({ note }) {
+  return (
+    <Link
+      to={`/notes/${note.id}`}
+      className="block bg-white rounded-lg border border-gray-200 p-4 hover:shadow-md transition"
+    >
+      <h3 className="font-semibold text-gray-900 truncate">{note.title}</h3>
+      {note.course && <p className="text-xs text-blue-600 mt-1 font-medium">{note.course}</p>}
+      {note.tags?.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-2">
+          {note.tags.map(tag => (
+            <span key={tag} className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{tag}</span>
+          ))}
+        </div>
+      )}
+      <p className="text-xs text-gray-400 mt-2">{new Date(note.created_at).toLocaleDateString()}</p>
+    </Link>
+  )
+}
+
+function ProfilePage() {
+  const { id } = useParams()
+  const { user: authUser } = useAuth()
+  const isOwnProfile = authUser?.id === id
+
+  const [profile, setProfile] = useState(null)
+  const [notes, setNotes] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [editingUsername, setEditingUsername] = useState(false)
+  const [newUsername, setNewUsername] = useState('')
+  const [usernameError, setUsernameError] = useState('')
+
+  useEffect(() => {
+    Promise.all([getUser(id), getUserNotes(id)])
+      .then(([p, n]) => { setProfile(p); setNotes(n) })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [id])
+
+  const handleUsernameUpdate = async () => {
+    setUsernameError('')
+    try {
+      const updated = await updateUsername(newUsername)
+      setProfile(p => ({ ...p, username: updated.username }))
+      setEditingUsername(false)
+    } catch (err) {
+      setUsernameError(err.message)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (!profile) {
+    return <div className="text-center py-20 text-gray-500">User not found.</div>
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="bg-white rounded-lg border border-gray-200 p-6 mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            {editingUsername ? (
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={newUsername}
+                  onChange={e => setNewUsername(e.target.value)}
+                  className="px-3 py-1.5 border border-gray-300 rounded-md text-lg font-bold focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  autoFocus
+                />
+                <button onClick={handleUsernameUpdate} className="text-sm text-blue-600 font-medium hover:text-blue-700">Save</button>
+                <button onClick={() => setEditingUsername(false)} className="text-sm text-gray-500 hover:text-gray-700">Cancel</button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-3">
+                <h1 className="text-2xl font-bold text-gray-900">{profile.username}</h1>
+                {isOwnProfile && (
+                  <button
+                    onClick={() => { setNewUsername(profile.username); setEditingUsername(true) }}
+                    className="text-xs text-gray-400 hover:text-blue-600 transition"
+                  >
+                    Edit username
+                  </button>
+                )}
+              </div>
+            )}
+            {usernameError && <p className="text-sm text-red-600 mt-1">{usernameError}</p>}
+            <p className="text-sm text-gray-500 mt-1">
+              Joined {new Date(profile.created_at).toLocaleDateString()}
+            </p>
+          </div>
+          <div className="text-center">
+            <p className="text-2xl font-bold text-blue-600">{profile.note_count}</p>
+            <p className="text-xs text-gray-500">public notes</p>
+          </div>
+        </div>
+      </div>
+
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Public Notes</h2>
+      {notes.length === 0 ? (
+        <p className="text-gray-500 text-center py-12">No public notes yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {notes.map(note => <NoteCard key={note.id} note={note} />)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ProfilePage

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -56,3 +56,15 @@ export async function updateNote(id, data) {
 export async function deleteNote(id) {
   return request(`/notes/${id}`, { method: 'DELETE' })
 }
+
+export async function getUser(id) {
+  return request(`/users/${id}`)
+}
+
+export async function getUserNotes(id) {
+  return request(`/users/${id}/notes`)
+}
+
+export async function updateUsername(username) {
+  return request('/users/me', { method: 'PUT', body: JSON.stringify({ username }) })
+}


### PR DESCRIPTION
## Summary
**Backend**
- `GET /api/users/:id` → `{ username, created_at, note_count }`
- `GET /api/users/:id/notes` → public notes by user (with tags + author)
- `PUT /api/users/me` → update own username (auth required, min 3 chars)

**Frontend**
- `ProfilePage` at `/profile/:id` — shows username, join date, public note count, notes grid
- Own profile (`authUser.id === id`) shows "Edit username" inline form
- `api.js` extended with `getUser`, `getUserNotes`, `updateUsername`

> Depends on PR #41 (notes pages)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)