### PR TITLE
Add Supabase Storage file upload endpoints

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -8,6 +8,7 @@ import notesRoutes from './routes/notes.js'
 import usersRoutes from './routes/users.js'
 import commentRouters from './routes/comments.js'
 import { notesRouter as likesNotesRouter, usersRouter as likesUsersRouter } from './routes/likes.js'
+import filesRouter from './routes/files.js'
 
 const app = express()
 const PORT = process.env.PORT || 5010
@@ -53,8 +54,11 @@ app.use('/api/comments', commentRouters.comments)
 app.use('/api/notes', likesNotesRouter)
 app.use('/api/users', likesUsersRouter)
 
+// Files
+app.use('/api/files', filesRouter)
+
 // Global error handler
-app.use((err, req, res, _next) => {
+app.use((err, _req, res, _next) => {
   console.error(err)
   res.status(500).json({ error: 'Internal server error' })
 })

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,7 +13,8 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "express-rate-limit": "^7.3.1",
-        "express-validator": "^7.1.0"
+        "express-validator": "^7.1.0",
+        "multer": "^2.1.1"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -133,6 +134,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -161,6 +168,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -199,6 +223,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -697,6 +736,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -804,6 +862,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/safe-buffer": {
@@ -964,6 +1036,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -992,6 +1081,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -1006,6 +1101,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-rate-limit": "^7.3.1",
-    "express-validator": "^7.1.0"
+    "express-validator": "^7.1.0",
+    "multer": "^2.1.1"
   }
 }

--- a/backend/routes/files.js
+++ b/backend/routes/files.js
@@ -1,0 +1,114 @@
+import { Router } from 'express'
+import multer from 'multer'
+import supabase from '../services/supabase.js'
+import { requireAuth } from '../middleware/auth.js'
+
+const router = Router()
+
+const ALLOWED_MIME_TYPES = ['application/pdf', 'image/png', 'image/jpeg']
+const BUCKET = 'note-files'
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true)
+    } else {
+      const err = new Error('Unsupported file type. Allowed: PDF, PNG, JPG, JPEG.')
+      err.code = 'UNSUPPORTED_TYPE'
+      cb(err)
+    }
+  },
+})
+
+function handleUpload(req, res, next) {
+  upload.single('file')(req, res, (err) => {
+    if (!err) return next()
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(413).json({ error: 'File too large. Max 10 MB.' })
+    }
+    if (err.code === 'UNSUPPORTED_TYPE') {
+      return res.status(415).json({ error: err.message })
+    }
+    return res.status(400).json({ error: err.message })
+  })
+}
+
+// POST /api/files
+router.post('/', requireAuth, handleUpload, async (req, res) => {
+  const { note_id } = req.body
+
+  if (!note_id) return res.status(400).json({ error: 'note_id is required' })
+  if (!req.file) return res.status(400).json({ error: 'file is required' })
+
+  const { data: note } = await supabase
+    .from('notes')
+    .select('user_id')
+    .eq('id', note_id)
+    .maybeSingle()
+
+  if (!note) return res.status(404).json({ error: 'Note not found' })
+  if (note.user_id !== req.user.id) return res.status(403).json({ error: 'Forbidden' })
+
+  const { originalname, mimetype, buffer, size } = req.file
+  const safeName = originalname.replace(/[^a-zA-Z0-9._-]/g, '_')
+  const storagePath = `${req.user.id}/${note_id}/${Date.now()}-${safeName}`
+
+  const { data: storageData, error: storageError } = await supabase.storage
+    .from(BUCKET)
+    .upload(storagePath, buffer, { contentType: mimetype })
+
+  if (storageError) return res.status(500).json({ error: storageError.message })
+
+  const { data: urlData } = supabase.storage
+    .from(BUCKET)
+    .getPublicUrl(storageData.path)
+
+  const { data: file, error: dbError } = await supabase
+    .from('files')
+    .insert({
+      note_id,
+      file_url: urlData.publicUrl,
+      file_name: originalname,
+      file_type: mimetype,
+      file_size: size,
+    })
+    .select('id, file_url, file_name, file_type, file_size')
+    .single()
+
+  if (dbError) {
+    await supabase.storage.from(BUCKET).remove([storagePath])
+    return res.status(500).json({ error: dbError.message })
+  }
+
+  return res.status(201).json(file)
+})
+
+// DELETE /api/files/:id
+router.delete('/:id', requireAuth, async (req, res) => {
+  const { data: file } = await supabase
+    .from('files')
+    .select('id, file_url, note_id, notes!fk_files_note(user_id)')
+    .eq('id', req.params.id)
+    .maybeSingle()
+
+  if (!file) return res.status(404).json({ error: 'File not found' })
+  if (file.notes.user_id !== req.user.id) return res.status(403).json({ error: 'Forbidden' })
+
+  const publicPrefix = `/storage/v1/object/public/${BUCKET}/`
+  const urlPath = new URL(file.file_url).pathname
+  const storagePath = urlPath.includes(publicPrefix)
+    ? urlPath.split(publicPrefix)[1]
+    : null
+
+  if (storagePath) {
+    await supabase.storage.from(BUCKET).remove([storagePath])
+  }
+
+  await supabase.from('files').delete().eq('id', req.params.id)
+
+  return res.status(204).send()
+})
+
+export default router


### PR DESCRIPTION

## Changes
- Add `POST /api/files` — accepts multipart/form-data with `file` and
  `note_id`; validates ownership, uploads to Supabase Storage at path
  `userId/noteId/timestamp-filename`, inserts record into `files` table,
  returns `201` with `{ id, file_url, file_name, file_type, file_size }`
- Add `DELETE /api/files/:id` — removes file from Supabase Storage and
  the `files` table; returns `204`; only the note owner can delete
- Add `multer` dependency for multipart/form-data parsing (memory storage)

## Validation & Error Handling
- Allowed types: PDF, PNG, JPG, JPEG — others return `415`
- Max file size: 10 MB — larger files return `413`
- Storage upload success but DB insert failure rolls back the storage
  upload to prevent orphaned files
- Note deletion cascades and removes all associated file records via
  `ON DELETE CASCADE` on the `files` table