### PR TITLE
After delete: redirect to / with success toast

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,12 +10,14 @@ import NoteFormPage from './pages/NoteFormPage'
 import NoteDetailPage from './pages/NoteDetailPage'
 import ProfilePage from './pages/ProfilePage'
 import CurriculumPage from './pages/CurriculumPage'
+import Toast from './components/Toast'
 
 function App() {
   return (
     <AuthProvider>
       <div className="min-h-screen bg-gray-50">
         <Navbar />
+        <Toast />
         <Routes>
           <Route path="/" element={<Navigate to="/notes" replace />} />
           <Route path="/login" element={<LoginPage />} />

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+function Toast() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    if (!location.state?.toast) return
+    setMessage(location.state.toast)
+    navigate(location.pathname, { replace: true, state: {} })
+    const t = setTimeout(() => setMessage(''), 3000)
+    return () => clearTimeout(t)
+  }, [location.state?.toast])
+
+  if (!message) return null
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-gray-900 text-white text-sm px-5 py-3 rounded-lg shadow-lg">
+      {message}
+    </div>
+  )
+}
+
+export default Toast

--- a/frontend/src/pages/NoteDetailPage.jsx
+++ b/frontend/src/pages/NoteDetailPage.jsx
@@ -25,7 +25,7 @@ function NoteDetailPage() {
     if (!window.confirm('Delete this note? This cannot be undone.')) return
     try {
       await deleteNote(id)
-      navigate('/')
+      navigate('/', { state: { toast: 'Note deleted.' } })
     } catch (err) {
       alert(err.message)
     }


### PR DESCRIPTION
fixed — passes { state: { toast: 'Note deleted.' } } to navigate, Toast.jsx reads it and auto-dismisses after 3s