### PR TITLE
feat: like & save buttons on note detail page (#26)

### DIFF
--- a/backend/routes/notes.js
+++ b/backend/routes/notes.js
@@ -191,20 +191,41 @@ router.get('/:id', async (req, res) => {
 
   if (error || !note) return res.status(404).json({ error: 'Note not found' })
 
+  const token = req.headers.authorization?.startsWith('Bearer ')
+    ? req.headers.authorization.slice(7)
+    : null
+
+  let userId = null
+
   if (!note.is_public) {
-    const token = req.headers.authorization?.startsWith('Bearer ')
-      ? req.headers.authorization.slice(7)
-      : null
-
     if (!token) return res.status(403).json({ error: 'Private note' })
-
     const { data: userData } = await supabase.auth.getUser(token)
     if (!userData?.user || userData.user.id !== note.user_id) {
       return res.status(403).json({ error: 'Private note' })
     }
+    userId = userData.user.id
+  } else if (token) {
+    const { data: userData } = await supabase.auth.getUser(token)
+    if (userData?.user) userId = userData.user.id
   }
 
-  return res.status(200).json(formatNote(note))
+  const { count: likeCount } = await supabase
+    .from('likes')
+    .select('*', { count: 'exact', head: true })
+    .eq('note_id', id)
+
+  let liked = false
+  let saved = false
+  if (userId) {
+    const [{ data: likeRow }, { data: saveRow }] = await Promise.all([
+      supabase.from('likes').select('user_id').eq('user_id', userId).eq('note_id', id).maybeSingle(),
+      supabase.from('saved_notes').select('user_id').eq('user_id', userId).eq('note_id', id).maybeSingle(),
+    ])
+    liked = !!likeRow
+    saved = !!saveRow
+  }
+
+  return res.status(200).json({ ...formatNote(note), like_count: likeCount ?? 0, liked, saved })
 })
 
 export default router

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -3,6 +3,27 @@ import supabase from '../services/supabase.js'
 
 const router = Router()
 
+// GET /api/users/:id
+router.get('/:id', async (req, res) => {
+  const { id } = req.params
+
+  const { data: user, error } = await supabase
+    .from('users')
+    .select('id, username, created_at')
+    .eq('id', id)
+    .single()
+
+  if (error || !user) return res.status(404).json({ error: 'User not found' })
+
+  const { count: noteCount } = await supabase
+    .from('notes')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', id)
+    .eq('is_public', true)
+
+  return res.status(200).json({ ...user, note_count: noteCount ?? 0 })
+})
+
 // GET /api/users/:id/notes
 router.get('/:id/notes', async (req, res) => {
   const { id } = req.params

--- a/frontend/src/pages/NoteDetailPage.jsx
+++ b/frontend/src/pages/NoteDetailPage.jsx
@@ -1,9 +1,33 @@
 import { useState, useEffect } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
-import { getNote, deleteNote } from '../services/api'
+import { getNote, deleteNote, toggleLike, toggleSave } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import FileUploader from '../components/FileUploader'
 import FilePreview from '../components/FilePreview'
+
+function HeartIcon({ filled }) {
+  return filled ? (
+    <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+      <path fillRule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clipRule="evenodd" />
+    </svg>
+  ) : (
+    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+    </svg>
+  )
+}
+
+function BookmarkIcon({ filled }) {
+  return filled ? (
+    <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z" />
+    </svg>
+  ) : (
+    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+    </svg>
+  )
+}
 
 function NoteDetailPage() {
   const { id } = useParams()
@@ -13,11 +37,20 @@ function NoteDetailPage() {
   const [note, setNote] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [liked, setLiked] = useState(false)
+  const [likeCount, setLikeCount] = useState(0)
+  const [saved, setSaved] = useState(false)
 
   useEffect(() => {
     document.title = 'Loading...'
     getNote(id)
-      .then(n => { setNote(n); document.title = n.title })
+      .then(n => {
+        setNote(n)
+        document.title = n.title
+        setLiked(n.liked ?? false)
+        setLikeCount(n.like_count ?? 0)
+        setSaved(n.saved ?? false)
+      })
       .catch(err => setError(err.message))
       .finally(() => setLoading(false))
     return () => { document.title = 'UniNotes' }
@@ -30,6 +63,34 @@ function NoteDetailPage() {
       navigate('/', { state: { toast: 'Note deleted.' } })
     } catch (err) {
       alert(err.message)
+    }
+  }
+
+  const handleLike = async () => {
+    if (!user) return
+    const prevLiked = liked
+    const prevCount = likeCount
+    setLiked(!liked)
+    setLikeCount(liked ? likeCount - 1 : likeCount + 1)
+    try {
+      const result = await toggleLike(id)
+      setLiked(result.liked)
+      setLikeCount(result.like_count)
+    } catch {
+      setLiked(prevLiked)
+      setLikeCount(prevCount)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!user) return
+    const prevSaved = saved
+    setSaved(!saved)
+    try {
+      const result = await toggleSave(id)
+      setSaved(result.saved)
+    } catch {
+      setSaved(prevSaved)
     }
   }
 
@@ -52,22 +113,65 @@ function NoteDetailPage() {
       <div className="bg-white rounded-lg border border-gray-200 p-6">
         <div className="flex items-start justify-between gap-4 mb-4">
           <h1 className="text-2xl font-bold text-gray-900">{note.title}</h1>
-          {isOwner && (
-            <div className="flex gap-2 shrink-0">
-              <Link
-                to={`/notes/${id}/edit`}
-                className="px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition"
-              >
-                Edit
-              </Link>
+          <div className="flex items-center gap-2 shrink-0">
+            {/* Like button */}
+            <div className="relative group">
               <button
-                onClick={handleDelete}
-                className="px-3 py-1.5 text-sm border border-red-200 text-red-600 rounded-md hover:bg-red-50 transition"
+                onClick={handleLike}
+                className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border transition ${
+                  liked
+                    ? 'border-red-300 text-red-500 bg-red-50 hover:bg-red-100'
+                    : 'border-gray-300 text-gray-500 hover:bg-gray-50'
+                } ${!user ? 'cursor-default' : 'cursor-pointer'}`}
+                aria-label="Like note"
               >
-                Delete
+                <HeartIcon filled={liked} />
+                <span>{likeCount}</span>
               </button>
+              {!user && (
+                <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 whitespace-nowrap rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 z-10">
+                  Log in to like
+                </span>
+              )}
             </div>
-          )}
+
+            {/* Save button */}
+            <div className="relative group">
+              <button
+                onClick={handleSave}
+                className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border transition ${
+                  saved
+                    ? 'border-blue-300 text-blue-600 bg-blue-50 hover:bg-blue-100'
+                    : 'border-gray-300 text-gray-500 hover:bg-gray-50'
+                } ${!user ? 'cursor-default' : 'cursor-pointer'}`}
+                aria-label="Save note"
+              >
+                <BookmarkIcon filled={saved} />
+              </button>
+              {!user && (
+                <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 whitespace-nowrap rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 z-10">
+                  Log in to save
+                </span>
+              )}
+            </div>
+
+            {isOwner && (
+              <>
+                <Link
+                  to={`/notes/${id}/edit`}
+                  className="px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition"
+                >
+                  Edit
+                </Link>
+                <button
+                  onClick={handleDelete}
+                  className="px-3 py-1.5 text-sm border border-red-200 text-red-600 rounded-md hover:bg-red-50 transition"
+                >
+                  Delete
+                </button>
+              </>
+            )}
+          </div>
         </div>
 
         <div className="flex flex-wrap items-center gap-3 text-sm text-gray-500 mb-6">

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { getUser, getUserNotes, updateUsername } from '../services/api'
+import { getUser, getUserNotes, updateUsername, getSavedNotes } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 
 function NoteCard({ note }) {
@@ -35,12 +35,33 @@ function ProfilePage() {
   const [newUsername, setNewUsername] = useState('')
   const [usernameError, setUsernameError] = useState('')
 
+  const [activeTab, setActiveTab] = useState('public')
+  const [savedNotes, setSavedNotes] = useState([])
+  const [loadingSaved, setLoadingSaved] = useState(false)
+  const [savedLoaded, setSavedLoaded] = useState(false)
+
   useEffect(() => {
     Promise.all([getUser(id), getUserNotes(id)])
       .then(([p, n]) => { setProfile(p); setNotes(n) })
       .catch(console.error)
       .finally(() => setLoading(false))
   }, [id])
+
+  const handleTabChange = async (tab) => {
+    setActiveTab(tab)
+    if (tab === 'saved' && !savedLoaded) {
+      setLoadingSaved(true)
+      try {
+        const data = await getSavedNotes()
+        setSavedNotes(data)
+        setSavedLoaded(true)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoadingSaved(false)
+      }
+    }
+  }
 
   const handleUsernameUpdate = async () => {
     setUsernameError('')
@@ -107,13 +128,57 @@ function ProfilePage() {
         </div>
       </div>
 
-      <h2 className="text-lg font-semibold text-gray-900 mb-4">Public Notes</h2>
-      {notes.length === 0 ? (
-        <p className="text-gray-500 text-center py-12">No public notes yet.</p>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {notes.map(note => <NoteCard key={note.id} note={note} />)}
+      {isOwnProfile && (
+        <div className="flex gap-1 mb-6 border-b border-gray-200">
+          <button
+            onClick={() => handleTabChange('public')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition ${
+              activeTab === 'public'
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Public Notes
+          </button>
+          <button
+            onClick={() => handleTabChange('saved')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition ${
+              activeTab === 'saved'
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Saved Notes
+          </button>
         </div>
+      )}
+
+      {!isOwnProfile && (
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Public Notes</h2>
+      )}
+
+      {activeTab === 'public' && (
+        notes.length === 0 ? (
+          <p className="text-gray-500 text-center py-12">No public notes yet.</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {notes.map(note => <NoteCard key={note.id} note={note} />)}
+          </div>
+        )
+      )}
+
+      {activeTab === 'saved' && (
+        loadingSaved ? (
+          <div className="flex justify-center py-12">
+            <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : savedNotes.length === 0 ? (
+          <p className="text-gray-500 text-center py-12">No saved notes yet.</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {savedNotes.map(note => <NoteCard key={note.id} note={note} />)}
+          </div>
+        )
       )}
     </div>
   )

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -83,6 +83,10 @@ export async function toggleSave(noteId) {
   return request(`/notes/${noteId}/save`, { method: 'POST' })
 }
 
+export async function getSavedNotes() {
+  return request('/users/me/saved')
+}
+
 export async function getComments(noteId) {
   return request(`/notes/${noteId}/comments`)
 }


### PR DESCRIPTION

- Heart button with live like count and optimistic toggle (`POST /api/notes/:id/like`)
- Bookmark button with filled/outline state (`POST /api/notes/:id/save`)
- Guest tooltip ("Log in to like/save") on both buttons for unauthenticated users
- Saved Notes tab on own profile page (`/profile/:id`), lazy-loaded
- Backend: `GET /api/notes/:id` now returns `like_count`, `liked`, `saved`; added missing `GET /api/users/:id` endpoint

Closes #26