### PR TITLE
feat: faculty/department/course grid browser with course note pages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run *)"
+    ]
+  }
+}

--- a/backend/routes/notes.js
+++ b/backend/routes/notes.js
@@ -27,6 +27,7 @@ function formatNote(note) {
     ...note,
     author: note.users?.username ?? null,
     tags: (note.note_tags || []).map(nt => nt.tags?.name).filter(Boolean),
+    files: note.files || [],
     users: undefined,
     note_tags: undefined,
   }
@@ -113,6 +114,30 @@ router.delete('/:id', requireAuth, async (req, res) => {
   return res.status(204).send()
 })
 
+// GET /api/notes/mine  — current user's own notes (including private)
+router.get('/mine', requireAuth, async (req, res) => {
+  const { course, page = 1, limit = 50 } = req.query
+  const offset = (Number(page) - 1) * Number(limit)
+
+  let query = supabase
+    .from('notes')
+    .select('*, users!fk_notes_user(username), note_tags(tags(name)), files(id, file_name, file_url, file_type, file_size)', { count: 'exact' })
+    .eq('user_id', req.user.id)
+
+  if (course) query = query.ilike('course', course)
+
+  query = query.order('created_at', { ascending: false }).range(offset, offset + Number(limit) - 1)
+
+  const { data: notes, count, error } = await query
+  if (error) return res.status(500).json({ error: error.message })
+
+  return res.status(200).json({
+    notes: (notes || []).map(formatNote),
+    total: count ?? 0,
+    hasNextPage: offset + (notes?.length ?? 0) < (count ?? 0),
+  })
+})
+
 // GET /api/notes
 router.get('/', async (req, res) => {
   const { page = 1, limit = 12, search, course, tag, sort = 'latest' } = req.query
@@ -120,7 +145,7 @@ router.get('/', async (req, res) => {
 
   let query = supabase
     .from('notes')
-    .select('*, users!fk_notes_user(username), note_tags(tags(name))', { count: 'exact' })
+    .select('*, users!fk_notes_user(username), note_tags(tags(name)), files(id, file_name, file_url, file_type, file_size)', { count: 'exact' })
     .eq('is_public', true)
 
   if (search) query = query.or(`title.ilike.%${search}%,content.ilike.%${search}%`)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import NoteFormPage from './pages/NoteFormPage'
 import NoteDetailPage from './pages/NoteDetailPage'
 import ProfilePage from './pages/ProfilePage'
 import CurriculumPage from './pages/CurriculumPage'
+import CoursePage from './pages/CoursePage'
 import Toast from './components/Toast'
 
 function App() {
@@ -34,6 +35,7 @@ function App() {
             <Route path="/notes/:id" element={<NoteDetailPage />} />
             <Route path="/profile/:id" element={<ProfilePage />} />
             <Route path="/departments/:slug" element={<CurriculumPage />} />
+            <Route path="/courses/:courseCode" element={<CoursePage />} />
             <Route path="*" element={<Navigate to="/notes" replace />} />
           </Routes>
         </div>

--- a/frontend/src/data/curriculum.js
+++ b/frontend/src/data/curriculum.js
@@ -1944,6 +1944,90 @@ export function getDepartmentBySlug(slug) {
   return DEPARTMENTS.find(d => d.slug === slug)
 }
 
+export const FACULTIES = [
+  {
+    slug: 'muhendislik',
+    name: 'Faculty of Engineering',
+    nametr: 'Mühendislik Fakültesi',
+    icon: '⚙️',
+    departments: [
+      'bilgisayar-muhendisligi',
+      'elektrik-elektronik-muhendisligi',
+      'endustri-muhendisligi',
+      'enerji-sistemleri-muhendisligi',
+      'insaat-muhendisligi',
+      'makine-muhendisligi',
+      'yazilim-muhendisligi',
+    ],
+  },
+  {
+    slug: 'mimarlik',
+    name: 'Faculty of Architecture',
+    nametr: 'Mimarlık Fakültesi',
+    icon: '🏛️',
+    departments: [
+      'mimarlik',
+      'ic-mimarlik-cevre-tasarimi',
+      'endustriyel-tasarim',
+    ],
+  },
+  {
+    slug: 'iletisim',
+    name: 'Faculty of Communication',
+    nametr: 'İletişim Fakültesi',
+    icon: '📡',
+    departments: [
+      'halkla-iliskiler-reklamcilik',
+      'radyo-tv-sinema',
+      'yeni-medya-iletisim',
+      'cizgi-film-animasyon',
+      'muzik',
+      'gorsel-iletisim-tasarimi',
+    ],
+  },
+  {
+    slug: 'iibf',
+    name: 'Faculty of Economics & Admin. Sciences',
+    nametr: 'İktisadi ve İdari Bilimler Fakültesi',
+    icon: '📊',
+    departments: [
+      'isletme',
+      'ekonomi',
+      'uluslararasi-iliskiler',
+      'uluslararasi-ticaret-finansman',
+      'lojistik-yonetimi',
+    ],
+  },
+  {
+    slug: 'hukuk',
+    name: 'Faculty of Law',
+    nametr: 'Hukuk Fakültesi',
+    icon: '⚖️',
+    departments: ['hukuk'],
+  },
+  {
+    slug: 'fen-edebiyat',
+    name: 'Faculty of Arts & Sciences',
+    nametr: 'Fen-Edebiyat Fakültesi',
+    icon: '📚',
+    departments: [
+      'ingiliz-dili-edebiyati',
+      'mutercim-tercumanlyk',
+      'psikoloji',
+    ],
+  },
+  {
+    slug: 'ziraat',
+    name: 'Faculty of Agriculture',
+    nametr: 'Ziraat Fakültesi',
+    icon: '🌾',
+    departments: [
+      'tarım-makineleri-muhendisligi',
+      'tarim-ekonomisi',
+    ],
+  },
+]
+
 // Map from Turkish department names (used in homepage sidebar) to slugs
 export const DEPT_NAME_TO_SLUG = {
   'Bilgisayar Mühendisliği': 'bilgisayar-muhendisligi',

--- a/frontend/src/pages/CoursePage.jsx
+++ b/frontend/src/pages/CoursePage.jsx
@@ -1,0 +1,232 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { getNotes, getMyNotes } from '../services/api'
+import { useAuth } from '../context/AuthContext'
+import { DEPARTMENTS } from '../data/curriculum'
+
+function findCourse(courseCode) {
+  for (const dept of DEPARTMENTS) {
+    for (const sem of dept.semesters) {
+      const course = sem.courses.find(c => c.code === courseCode)
+      if (course) return { course, dept, semester: sem.semester }
+    }
+  }
+  return null
+}
+
+function FileIcon({ type }) {
+  if (type?.includes('pdf')) return '📄'
+  if (type?.includes('image')) return '🖼️'
+  if (type?.includes('word') || type?.includes('document')) return '📝'
+  if (type?.includes('sheet') || type?.includes('excel')) return '📊'
+  if (type?.includes('presentation') || type?.includes('powerpoint')) return '📑'
+  return '📎'
+}
+
+function NoteCard({ note, isOwn }) {
+  return (
+    <Link
+      to={`/notes/${note.id}`}
+      className="block bg-white rounded-lg border border-gray-200 p-4 hover:shadow-md transition"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="font-semibold text-gray-900 truncate">{note.title}</h3>
+        <div className="flex items-center gap-1 shrink-0">
+          {isOwn && !note.is_public && (
+            <span className="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">private</span>
+          )}
+          {note.files?.length > 0 && (
+            <span className="text-xs bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded">
+              {note.files.length} file{note.files.length > 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <p className="text-sm text-gray-500 mt-1">by {note.author}</p>
+
+      {note.tags?.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-2">
+          {note.tags.map(tag => (
+            <span key={tag} className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{tag}</span>
+          ))}
+        </div>
+      )}
+
+      {note.files?.length > 0 && (
+        <div className="mt-3 space-y-1">
+          {note.files.map(file => (
+            <div key={file.id} className="flex items-center gap-2 text-xs text-gray-500">
+              <span><FileIcon type={file.file_type} /></span>
+              <span className="truncate">{file.file_name}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between mt-3 text-xs text-gray-400">
+        <span>{new Date(note.created_at).toLocaleDateString()}</span>
+        <span>♥ {note.like_count ?? 0}</span>
+      </div>
+    </Link>
+  )
+}
+
+function CoursePage() {
+  const { courseCode } = useParams()
+  const { user } = useAuth()
+
+  const decoded = decodeURIComponent(courseCode)
+  const found = findCourse(decoded)
+
+  const [publicNotes, setPublicNotes] = useState([])
+  const [myPrivateNotes, setMyPrivateNotes] = useState([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [page, setPage] = useState(1)
+  const [hasNextPage, setHasNextPage] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+
+    const fetches = [
+      getNotes({ course: decoded, page, limit: 12 }),
+    ]
+    if (user) {
+      fetches.push(getMyNotes({ course: decoded, limit: 50 }))
+    }
+
+    Promise.all(fetches)
+      .then(([pubData, myData]) => {
+        setPublicNotes(pubData.notes)
+        setTotal(pubData.total)
+        setHasNextPage(pubData.hasNextPage)
+
+        if (myData) {
+          const pubIds = new Set(pubData.notes.map(n => n.id))
+          setMyPrivateNotes(myData.notes.filter(n => !n.is_public && !pubIds.has(n.id)))
+        }
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [decoded, page, user])
+
+  if (!found) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-16 text-center text-gray-500">
+        Course not found.{' '}
+        <Link to="/notes" className="text-blue-600 hover:underline">Go back</Link>
+      </div>
+    )
+  }
+
+  const { course, dept, semester } = found
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-2 text-xs text-gray-400 mb-6">
+        <Link to="/notes" className="hover:text-gray-600">Home</Link>
+        <span>›</span>
+        <Link to={`/departments/${dept.slug}`} className="hover:text-gray-600">{dept.name}</Link>
+        <span>›</span>
+        <span className="text-gray-600 font-medium">{course.code}</span>
+      </nav>
+
+      {/* Course info card */}
+      <div className="bg-white border border-gray-200 rounded-xl p-6 mb-8">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <span className="text-xs font-mono font-semibold text-blue-600 bg-blue-50 px-2 py-1 rounded">
+              {course.code}
+            </span>
+            <h1 className="text-xl font-bold text-gray-900 mt-3">{course.name}</h1>
+            <p className="text-sm text-gray-500 mt-1">{dept.name} · Semester {semester}</p>
+          </div>
+          <div className="text-right shrink-0">
+            <div className={`inline-block text-xs px-3 py-1 rounded-full font-medium ${
+              course.type === 'Required' ? 'bg-blue-50 text-blue-700' : 'bg-amber-50 text-amber-700'
+            }`}>
+              {course.type}
+            </div>
+            <div className="text-2xl font-bold text-gray-900 mt-2">{course.ects}</div>
+            <div className="text-xs text-gray-400">ECTS</div>
+          </div>
+        </div>
+        <div className="mt-4 pt-4 border-t border-gray-100 text-sm text-gray-500">
+          T+U+L: <span className="font-medium text-gray-700">{course.tul}</span>
+        </div>
+      </div>
+
+      {/* My private notes section */}
+      {myPrivateNotes.length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">My Notes</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {myPrivateNotes.map(note => (
+              <NoteCard key={note.id} note={note} isOwn />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Public notes section */}
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-bold text-gray-900">
+          {myPrivateNotes.length > 0 ? 'Public Notes' : 'Notes'}
+          {total > 0 && <span className="text-gray-400 font-normal text-base ml-1">({total})</span>}
+        </h2>
+        {user ? (
+          <Link
+            to={`/notes/new?course=${encodeURIComponent(decoded)}`}
+            className="bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-blue-700 transition"
+          >
+            + Create Note
+          </Link>
+        ) : (
+          <Link to="/login" className="text-sm text-blue-600 hover:underline">
+            Log in to create a note
+          </Link>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : publicNotes.length === 0 ? (
+        <div className="text-center py-16 text-gray-400">
+          <p className="text-lg mb-2">No public notes yet for this course.</p>
+          {user && (
+            <Link
+              to={`/notes/new?course=${encodeURIComponent(decoded)}`}
+              className="text-blue-600 hover:underline text-sm"
+            >
+              Be the first to share one →
+            </Link>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {publicNotes.map(note => <NoteCard key={note.id} note={note} isOwn={note.author === user?.username} />)}
+        </div>
+      )}
+
+      {(page > 1 || hasNextPage) && (
+        <div className="flex justify-center items-center gap-4 mt-8">
+          <button onClick={() => setPage(p => p - 1)} disabled={page === 1}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-md disabled:opacity-40 hover:bg-gray-50 transition">
+            Previous
+          </button>
+          <span className="text-sm text-gray-600">Page {page}</span>
+          <button onClick={() => setPage(p => p + 1)} disabled={!hasNextPage}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-md disabled:opacity-40 hover:bg-gray-50 transition">
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CoursePage

--- a/frontend/src/pages/CurriculumPage.jsx
+++ b/frontend/src/pages/CurriculumPage.jsx
@@ -40,6 +40,7 @@ function CurriculumPage() {
 }
 
 function SemesterTable({ semester }) {
+  const { t } = useLocale()
   const totalEcts = semester.courses.reduce((sum, c) => sum + c.ects, 0)
 
   return (

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -3,8 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { getNotes, getCourses } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import { useLocale } from '../context/LocaleContext'
-import { DEPT_NAME_TO_SLUG } from '../data/curriculum'
-import StudentLoungeHero from '../components/StudentLoungeHero'
+import { DEPARTMENTS, FACULTIES } from '../data/curriculum'
 
 function useDebounce(value, delay) {
   const [debounced, setDebounced] = useState(value)
@@ -15,39 +14,134 @@ function useDebounce(value, delay) {
   return debounced
 }
 
-const DEPARTMENTS = [
-  'Computer Engineering',
-  'Cartoon and Animation',
-  'Economics',
-  'Electrical-Electronics Engineering',
-  'Industrial Engineering',
-  'Industrial Design',
-  'Energy Systems Engineering',
-  'Gastronomy and Culinary Arts',
-  'Visual Communication Design',
-  'Public Relations and Advertising',
-  'Law',
-  'Interior Architecture and Environmental Design',
-  'English Language and Literature',
-  'English Translation and Interpretation',
-  'Civil Engineering',
-  'Business Administration',
-  'Logistics Management',
-  'Mechanical Engineering',
-  'Architecture',
-  'Psychology',
-  'Radio, Television and Cinema',
-  'Agricultural Economics',
-  'Agricultural Machinery and Technologies Engineering',
-  'Tourism Guidance',
-  'International Relations',
-  'International Trade and Finance',
-  'Software Engineering',
-  'New Media and Communication',
-  'Management Information Systems',
-]
+function FacultyGrid({ selectedFaculty, onSelect }) {
+  return (
+    <div className="mb-8">
+      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Browse by Faculty</h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+        {FACULTIES.map(faculty => {
+          const isSelected = selectedFaculty?.slug === faculty.slug
+          return (
+            <button
+              key={faculty.slug}
+              onClick={() => onSelect(isSelected ? null : faculty)}
+              className={`text-left p-4 rounded-xl border-2 transition ${
+                isSelected
+                  ? 'border-blue-600 bg-blue-50'
+                  : 'border-gray-200 bg-white hover:border-blue-300 hover:bg-gray-50'
+              }`}
+            >
+              <div className="text-2xl mb-2">{faculty.icon}</div>
+              <div className={`text-sm font-semibold leading-tight ${isSelected ? 'text-blue-700' : 'text-gray-800'}`}>
+                {faculty.name}
+              </div>
+              <div className="text-xs text-gray-400 mt-1">{faculty.departments.length} departments</div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
 
-function NoteCard({ note }) {
+function DepartmentGrid({ faculty, selectedDept, onSelect }) {
+  const depts = faculty.departments
+    .map(slug => DEPARTMENTS.find(d => d.slug === slug))
+    .filter(Boolean)
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-lg">{faculty.icon}</span>
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide">
+          {faculty.name} — Departments
+        </h2>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+        {depts.map(dept => {
+          const isSelected = selectedDept?.slug === dept.slug
+          const totalCourses = dept.semesters.reduce((acc, s) => acc + s.courses.length, 0)
+          return (
+            <button
+              key={dept.slug}
+              onClick={() => onSelect(isSelected ? null : dept)}
+              className={`text-left p-4 rounded-xl border-2 transition ${
+                isSelected
+                  ? 'border-blue-600 bg-blue-50'
+                  : 'border-gray-200 bg-white hover:border-blue-300 hover:bg-gray-50'
+              }`}
+            >
+              <div className={`text-sm font-semibold leading-tight ${isSelected ? 'text-blue-700' : 'text-gray-800'}`}>
+                {dept.name}
+              </div>
+              <div className="text-xs text-gray-400 mt-1">{totalCourses} courses · {dept.semesters.length} semesters</div>
+              <Link
+                to={`/departments/${dept.slug}`}
+                onClick={e => e.stopPropagation()}
+                className="inline-block mt-2 text-xs text-blue-500 hover:text-blue-700"
+              >
+                View notes →
+              </Link>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function CourseList({ dept }) {
+  return (
+    <div className="mb-8">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide">
+          {dept.name} — Courses
+        </h2>
+        <Link to={`/departments/${dept.slug}`} className="text-xs text-blue-600 hover:underline">
+          View all notes →
+        </Link>
+      </div>
+      <div className="space-y-4">
+        {dept.semesters.map(sem => (
+          <div key={sem.semester} className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+            <div className="bg-gray-50 border-b border-gray-200 px-4 py-2">
+              <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
+                Semester {sem.semester}
+              </span>
+            </div>
+            <div className="divide-y divide-gray-100">
+              {sem.courses.map(course => (
+                <Link
+                  key={course.code}
+                  to={`/courses/${encodeURIComponent(course.code)}`}
+                  className="flex items-center justify-between px-4 py-3 hover:bg-blue-50 transition group"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="text-xs font-mono font-semibold text-blue-600 shrink-0">{course.code}</span>
+                    <span className="text-sm text-gray-800 truncate group-hover:text-blue-700">{course.name}</span>
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0 ml-4">
+                    <span className="text-xs text-gray-400">{course.tul}</span>
+                    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                      course.type === 'Required'
+                        ? 'bg-blue-50 text-blue-700'
+                        : 'bg-amber-50 text-amber-700'
+                    }`}>
+                      {course.ects} ECTS
+                    </span>
+                    <span className="text-xs text-gray-300 group-hover:text-blue-400">→</span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function NoteCard({ note, locale }) {
   return (
     <Link
       to={`/notes/${note.id}`}
@@ -86,7 +180,9 @@ function HomePage() {
   const [searchInput, setSearchInput] = useState('')
   const [course, setCourse] = useState(() => searchParams.get('course') ?? '')
   const [tag, setTag] = useState('')
-  const [department, setDepartment] = useState('')
+
+  const [selectedFaculty, setSelectedFaculty] = useState(null)
+  const [selectedDept, setSelectedDept] = useState(null)
 
   useEffect(() => {
     getCourses().then(setCourses).catch(() => {})
@@ -99,28 +195,39 @@ function HomePage() {
     const params = { page, limit: 12 }
     if (debouncedSearch) params.search = debouncedSearch
     if (course) params.course = course
-    if (department) params.course = department
     if (tag) params.tag = tag
 
     getNotes(params)
       .then(data => { setNotes(data.notes); setTotal(data.total); setHasNextPage(data.hasNextPage) })
       .catch(console.error)
       .finally(() => setLoading(false))
-  }, [page, debouncedSearch, course, department, tag])
+  }, [page, debouncedSearch, course, tag])
 
-  useEffect(() => { setPage(1) }, [debouncedSearch, course, department, tag])
+  useEffect(() => { setPage(1) }, [debouncedSearch, course, tag])
   useEffect(() => { fetchNotes() }, [fetchNotes])
 
-  const clearFilters = () => { setSearchInput(''); setCourse(''); setTag(''); setDepartment('') }
-  const hasFilters = searchInput || course || tag || department
+  const clearFilters = () => { setSearchInput(''); setCourse(''); setTag('') }
+  const hasFilters = searchInput || course || tag
+
+  const handleFacultySelect = (faculty) => {
+    setSelectedFaculty(faculty)
+    setSelectedDept(null)
+  }
 
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
-      <StudentLoungeHero
-        searchInput={searchInput}
-        onSearchChange={setSearchInput}
-        isLoggedIn={Boolean(user)}
-      />
+
+      <FacultyGrid selectedFaculty={selectedFaculty} onSelect={handleFacultySelect} />
+
+      {selectedFaculty && (
+        <DepartmentGrid
+          faculty={selectedFaculty}
+          selectedDept={selectedDept}
+          onSelect={setSelectedDept}
+        />
+      )}
+
+      {selectedDept && <CourseList dept={selectedDept} />}
 
       <div id="notes-list" className="scroll-mt-24" />
 
@@ -135,156 +242,73 @@ function HomePage() {
         )}
       </div>
 
-      <div className="flex gap-6 items-start">
-        {/* Departments sidebar */}
-        <aside className="hidden lg:block w-56 shrink-0">
-          <div className="bg-white border border-gray-200 rounded-lg p-4 sticky top-4">
-            <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">Yaşar University Departments</h2>
-            <ul className="space-y-0.5">
-              {DEPARTMENTS.map(dept => {
-                const slug = DEPT_NAME_TO_SLUG[dept]
-                return (
-                  <li key={dept}>
-                    {slug ? (
-                      <Link
-                        to={`/departments/${slug}`}
-                        className="block w-full text-left text-xs px-2 py-1.5 rounded transition text-gray-600 hover:bg-gray-100"
-                      >
-                        {dept}
-                        <span className="ml-1 text-blue-400 text-[10px]">→</span>
-                      </Link>
-                    ) : (
-                      <button
-                        onClick={() => { setDepartment(dept === department ? '' : dept); setCourse('') }}
-                        className={`w-full text-left text-xs px-2 py-1.5 rounded transition ${
-                          department === dept
-                            ? 'bg-blue-600 text-white font-medium'
-                            : 'text-gray-600 hover:bg-gray-100'
-                        }`}
-                      >
-                        {dept}
-                      </button>
-                    )}
-                  </li>
-                )
-              })}
-            </ul>
-          </div>
-        </aside>
-
-        {/* Main content */}
-        <div className="flex-1 min-w-0">
-          {/* Mobile departments (horizontal scroll) */}
-          <div className="lg:hidden mb-4 -mx-1">
-            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2 px-1">Departments</p>
-            <div className="flex gap-2 overflow-x-auto pb-2">
-              {DEPARTMENTS.map(dept => {
-                const slug = DEPT_NAME_TO_SLUG[dept]
-                return slug ? (
-                  <Link
-                    key={dept}
-                    to={`/departments/${slug}`}
-                    className="shrink-0 text-xs px-3 py-1.5 rounded-full border border-blue-300 text-blue-700 hover:bg-blue-50 transition"
-                  >
-                    {dept}
-                  </Link>
-                ) : (
-                  <button
-                    key={dept}
-                    onClick={() => { setDepartment(dept === department ? '' : dept); setCourse('') }}
-                    className={`shrink-0 text-xs px-3 py-1.5 rounded-full border transition ${
-                      department === dept
-                        ? 'bg-blue-600 border-blue-600 text-white font-medium'
-                        : 'border-gray-300 text-gray-600 hover:bg-gray-50'
-                    }`}
-                  >
-                    {dept}
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-
-          {/* Filters */}
-          <div className="bg-white border border-gray-200 rounded-lg p-4 mb-6 flex flex-wrap gap-3 items-end">
-            <div className="flex-1 min-w-48">
-              <label className="block text-xs font-medium text-gray-600 mb-1">{t('searchNotes')}</label>
-              <input
-                type="text"
-                placeholder={t('searchNotes')}
-                value={searchInput}
-                onChange={e => setSearchInput(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-            <div className="min-w-36">
-              <label className="block text-xs font-medium text-gray-600 mb-1">{t('course')}</label>
-              <select
-                value={course}
-                onChange={e => { setCourse(e.target.value); setDepartment('') }}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value="">{t('allCourses')}</option>
-              {courses.map(c => <option key={c} value={c}>{c}</option>)}
-              </select>
-            </div>
-            <div className="min-w-36">
-              <label className="block text-xs font-medium text-gray-600 mb-1">{t('tags')}</label>
-              <input
-                type="text"
-                placeholder="e.g. exam"
-                value={tag}
-                onChange={e => setTag(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-            {hasFilters && (
-              <button onClick={clearFilters} className="px-4 py-2 text-sm text-gray-500 hover:text-red-600 border border-gray-300 rounded-md hover:border-red-300 transition">
-                {t('clearFilters')}
-              </button>
-            )}
-          </div>
-
-          {department && (
-            <div className="mb-4 flex items-center gap-2">
-              <span className="text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 px-3 py-1 rounded-full">
-                {department}
-              </span>
-              <button onClick={() => setDepartment('')} className="text-xs text-gray-400 hover:text-gray-600">
-                ✕ {t('remove')}
-              </button>
-            </div>
-          )}
-
-          {loading ? (
-            <div className="flex justify-center py-20">
-              <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
-            </div>
-          ) : notes.length === 0 ? (
-            <div className="text-center py-20 text-gray-500">
-              {hasFilters ? t('noNotesMatchFilters') : t('noNotesFound')}
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-              {notes.map(note => <NoteCard key={note.id} note={note} />)}
-            </div>
-          )}
-
-          {(page > 1 || hasNextPage) && (
-            <div className="flex justify-center items-center gap-4 mt-8">
-              <button onClick={() => setPage(p => p - 1)} disabled={page === 1}
-                className="px-4 py-2 text-sm border border-gray-300 rounded-md disabled:opacity-40 hover:bg-gray-50 transition">
-                {t('previous')}
-              </button>
-              <span className="text-sm text-gray-600">{t('page')} {page}</span>
-              <button onClick={() => setPage(p => p + 1)} disabled={!hasNextPage}
-                className="px-4 py-2 text-sm border border-gray-300 rounded-md disabled:opacity-40 hover:bg-gray-50 transition">
-                {t('next')}
-              </button>
-            </div>
-          )}
+      {/* Filters */}
+      <div className="bg-white border border-gray-200 rounded-lg p-4 mb-6 flex flex-wrap gap-3 items-end">
+        <div className="flex-1 min-w-48">
+          <label className="block text-xs font-medium text-gray-600 mb-1">{t('searchNotes')}</label>
+          <input
+            type="text"
+            placeholder={t('searchNotes')}
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
         </div>
+        <div className="min-w-36">
+          <label className="block text-xs font-medium text-gray-600 mb-1">{t('course')}</label>
+          <select
+            value={course}
+            onChange={e => setCourse(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">{t('allCourses')}</option>
+            {courses.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </div>
+        <div className="min-w-36">
+          <label className="block text-xs font-medium text-gray-600 mb-1">{t('tags')}</label>
+          <input
+            type="text"
+            placeholder="e.g. exam"
+            value={tag}
+            onChange={e => setTag(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        {hasFilters && (
+          <button onClick={clearFilters} className="px-4 py-2 text-sm text-gray-500 hover:text-red-600 border border-gray-300 rounded-md hover:border-red-300 transition">
+            {t('clearFilters')}
+          </button>
+        )}
       </div>
+
+      {loading ? (
+        <div className="flex justify-center py-20">
+          <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : notes.length === 0 ? (
+        <div className="text-center py-20 text-gray-500">
+          {hasFilters ? t('noNotesMatchFilters') : t('noNotesFound')}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+          {notes.map(note => <NoteCard key={note.id} note={note} locale={locale} />)}
+        </div>
+      )}
+
+      {(page > 1 || hasNextPage) && (
+        <div className="flex justify-center items-center gap-4 mt-8">
+          <button onClick={() => setPage(p => p - 1)} disabled={page === 1}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-md disabled:opacity-40 hover:bg-gray-50 transition">
+            {t('previous')}
+          </button>
+          <span className="text-sm text-gray-600">{t('page')} {page}</span>
+          <button onClick={() => setPage(p => p + 1)} disabled={!hasNextPage}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-md disabled:opacity-40 hover:bg-gray-50 transition">
+            {t('next')}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/NoteDetailPage.jsx
+++ b/frontend/src/pages/NoteDetailPage.jsx
@@ -113,6 +113,19 @@ function NoteDetailPage() {
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
+      {note.course && (
+        <div className="mb-4">
+          <Link
+            to={`/courses/${encodeURIComponent(note.course)}`}
+            className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-600 transition"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd" />
+            </svg>
+            {note.course}
+          </Link>
+        </div>
+      )}
       <div className="bg-white rounded-lg border border-gray-200 p-6">
         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
           <h1 className="text-2xl font-bold text-gray-900">{note.title}</h1>
@@ -184,9 +197,12 @@ function NoteDetailPage() {
             </Link>
           )}
           {note.course && (
-            <span className="bg-blue-50 text-blue-700 px-2 py-0.5 rounded text-xs font-medium">
+            <Link
+              to={`/courses/${encodeURIComponent(note.course)}`}
+              className="bg-blue-50 text-blue-700 px-2 py-0.5 rounded text-xs font-medium hover:bg-blue-100 transition"
+            >
               {note.course}
-            </span>
+            </Link>
           )}
           <span>{new Date(note.created_at).toLocaleDateString(locale)}</span>
         </div>

--- a/frontend/src/pages/NoteFormPage.jsx
+++ b/frontend/src/pages/NoteFormPage.jsx
@@ -1,18 +1,19 @@
 import { useState, useEffect } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { createNote, updateNote, getNote } from '../services/api'
 import { useLocale } from '../context/LocaleContext'
 
 function NoteFormPage() {
   const navigate = useNavigate()
   const { id } = useParams()
+  const [searchParams] = useSearchParams()
   const { t } = useLocale()
   const isEdit = Boolean(id)
 
   const [formData, setFormData] = useState({
     title: '',
     content: '',
-    course: '',
+    course: searchParams.get('course') ?? '',
     is_public: false,
     tags: '',
   })

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -3,7 +3,6 @@ import { useParams, Link } from 'react-router-dom'
 import { getUser, getUserNotes, updateUsername, getSavedNotes } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import { useLocale } from '../context/LocaleContext'
-import { useLocale } from '../context/LocaleContext'
 
 function NoteCard({ note }) {
   return (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -47,6 +47,11 @@ export async function getNotes(params = {}) {
   return request(`/notes${query ? `?${query}` : ''}`)
 }
 
+export async function getMyNotes(params = {}) {
+  const query = new URLSearchParams(params).toString()
+  return request(`/notes/mine${query ? `?${query}` : ''}`)
+}
+
 export async function getNote(id) {
   return request(`/notes/${id}`)
 }


### PR DESCRIPTION

## Summary

- Removed `StudentLoungeHero` dark-themed hero section from homepage
- Built a 3-level interactive grid browser on the homepage: Faculty → Department → Courses
- Added faculty grouping data (`FACULTIES`) to `curriculum.js` mapping 27 departments into 7 faculties
- Each course row in the grid links to a dedicated course page
- Created `CoursePage` (`/courses/:courseCode`) showing course info, the user's own notes (including private), and public notes for that course — with file attachments visible on each note card
- Added `GET /api/notes/mine` backend endpoint returning the authenticated user's own notes, optionally filtered by course
- Added `files` to the note list query so attachments are returned in list responses (not just detail)
- Pre-fills the course field in `NoteFormPage` when navigating from a course page via `?course=` query param
- Added a back button on `NoteDetailPage` linking back to the course page when a note has a course set; course badge is also now a clickable link
- Fixed `SemesterTable` crash in `CurriculumPage` caused by missing `useLocale()` call
- Fixed duplicate `useLocale` import in `ProfilePage`

## Files changed

- `frontend/src/data/curriculum.js` — added `FACULTIES` export
- `frontend/src/pages/HomePage.jsx` — replaced hero + flat sidebar with 3-level grid
- `frontend/src/pages/CoursePage.jsx` — new page
- `frontend/src/pages/NoteDetailPage.jsx` — back-to-course button + clickable course badge
- `frontend/src/pages/NoteFormPage.jsx` — pre-fill course from query param
- `frontend/src/pages/CurriculumPage.jsx` — fixed `useLocale` missing in `SemesterTable`
- `frontend/src/pages/ProfilePage.jsx` — removed duplicate import
- `frontend/src/services/api.js` — added `getMyNotes`
- `frontend/src/App.jsx` — added `/courses/:courseCode` route
- `backend/routes/notes.js` — added `GET /notes/mine`, added `files` to list queries, updated `formatNote`
