### PR TITLE
fix: add root vercel.json to build frontend subfolder

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "buildCommand": "cd frontend && npm install && npm run build",
+  "outputDirectory": "frontend/dist",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Vercel was trying to build from repo root but the app is in `frontend/`
- Adds `vercel.json` at repo root with correct build command, output directory, and SPA rewrites

## Changes
- `buildCommand`: `cd frontend && npm install && npm run build`
- `outputDirectory`: `frontend/dist`
- SPA rewrite: all routes → `/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)